### PR TITLE
style: logo section size

### DIFF
--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -24,8 +24,8 @@ const Popup = () => {
     updateUrlsInChromeStorage(newUrls);
   };
 
-  const handleClickGoToOfficialWebsite = () => {
-    chrome.tabs.create({ url: 'https://opensumi.com/' });
+  const handleClickGoToRepo = () => {
+    chrome.tabs.create({ url: 'https://github.com/opensumi/shortcuts-guard' });
   };
 
   const handlePressAddUrlEnter = (
@@ -175,14 +175,14 @@ const Popup = () => {
           <img
             src="../images/logo.svg"
             className={styles.logo}
-            onClick={handleClickGoToOfficialWebsite}
+            onClick={handleClickGoToRepo}
           />
           <div className={styles['vertical-divider']} />
           <span
             className={styles['sumi-name']}
-            onClick={handleClickGoToOfficialWebsite}
+            onClick={handleClickGoToRepo}
           >
-            OpenSumi
+            OpenSumi Guard
           </span>
         </div>
         <Tooltip title={chrome.i18n.getMessage('goShortcut')} delay={600}>

--- a/src/pages/popup/popup.module.less
+++ b/src/pages/popup/popup.module.less
@@ -5,27 +5,30 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  height: 47px;
 
   .left-wrapper {
     display: flex;
     align-items: center;
+    padding-left: 5px;
+    margin-bottom: 5px;
 
     .logo {
       cursor: pointer;
-      width: 35px;
-      height: 35px;
+      width: 30px;
+      height: 30px;
     }
 
     .sumi-name {
       cursor: pointer;
-      font-size: 16px;
+      font-size: 14px;
     }
 
     .vertical-divider {
       background-color: var(--kt-modal-separatorBackground);
       width: 1px;
-      height: 20px;
-      margin: 15px;
+      height: 15px;
+      margin: 10px;
     }
   }
 


### PR DESCRIPTION
### Background or solution
before:
![before](https://user-images.githubusercontent.com/85668115/180801686-eb1192ca-90e6-4657-88f2-856326c2cc46.png)

after:
![after](https://user-images.githubusercontent.com/85668115/180801555-85842fb2-fc10-4ef0-aa58-9e471115d301.png)

### Changelog
-  缩小了 logo 区域大小
-  logo name 修改为 OpenSumi Guard
-  点击 logo 会跳转到 shortcuts guard 仓库