### PR TITLE
style: right align content

### DIFF
--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -215,7 +215,7 @@ const Popup = () => {
         style={{
           fontSize: '16px',
           height: '160px',
-          width: 'calc(100vw - 10px)',
+          width: 'calc(100vw - 15px)',
           willChange: 'initial',
           transform: 'none',
         }}

--- a/src/pages/popup/popup.module.less
+++ b/src/pages/popup/popup.module.less
@@ -1,6 +1,11 @@
 @import '~@opensumi/ide-components/lib/icon/iconfont/iconfont.css';
 @import '/src/styles/variables.less';
 
+body {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
 .header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
### Background or solution
before:
![before](https://user-images.githubusercontent.com/85668115/180809288-f6f89000-e8e8-4da2-a825-1206ee793ab5.png)

after:
![after](https://user-images.githubusercontent.com/85668115/180809809-db7caf90-541d-436c-95ba-df5fd962ea68.png)

![after2](https://user-images.githubusercontent.com/85668115/180809353-490ea2c8-1808-4e04-8101-2e4856108146.png)

### Changelog
调整 body 的内间距和列表的宽度，达到页面内容的右对齐

