### PR TITLE
feat: use match patterns

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -9,8 +9,32 @@ OpenSumi IDE 快捷键存在和谷歌浏览器快捷键冲突的情况，这些�
 ## 使用说明
 
 - 点击插件图标，然后会出现一个 popup 页面。
-- 在 popup 页面中输入 URL ，插件会在你输入的 URL 上守护 OpenSumi IDE 快捷键。
+- 在 popup 页面中输入可为匹配模式的 URL，插件会在你输入的 URL 上守护 OpenSumi IDE 快捷键。
 - 点击 popup 页面右上角键盘图标，前往[快捷键设置页面](chrome://extensions/shortcuts)，然后输入冲突的快捷键。
+
+## 匹配模式
+
+### 基本语法
+
+```text
+<url-pattern> := <scheme>://<host><path>
+<scheme> := '*' | 'http' | 'https'
+<host> := '*' | '*.' <any char except '/' and '*'>+
+<path> := '/' <any chars>
+```
+
+### 例子
+
+| 模式                               | 它有什么效果                                                 | 匹配的 URLs 例子                                             |
+| ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `https://*/*`                      | 匹配任何使用 `https` scheme 的 URL                           | https://www.google.com/<br/>https://example.org/foo/bar.html |
+| `https://*/foo*`                   | 匹配任何使用 `https` scheme 且 path 以`/foo`开头的 URL       | https://example.com/foo/bar.html<br/>https://www.google.com/foo |
+| `https://*.google.com/foo*bar`     | 匹配任何使用 `https` scheme、基于 google.com 的 host（例如 www.google.com、docs.google.com 或 google.com）且 path 以 `/foo` 开头并以 `bar` 结尾的 URL | https://www.google.com/foo/baz/bar<br/>https://docs.google.com/foobar |
+| `https://example.org/foo/bar.html` | 匹配指定的 URL                                               | https://example.org/foo/bar.html                             |
+| `http://127.0.0.1/*`               | 匹配任何使用 `http` scheme 且 host 为 127.0.0.1 的 URL       | http://127.0.0.1/<br/>http://127.0.0.1/foo/bar.html          |
+| `*://mail.google.com/*`            | 匹配任何以 `http://mail.google.com` 或 `https://mail.google.com` 开头的 URL | http://mail.google.com/foo/baz/bar<br/>https://mail.google.com/foobar |
+
+> 参考 [Match patterns - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/match_patterns/)
 
 ## 守护的快捷键
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,32 @@ The shortcuts of the OpenSumi IDE conflict with those of the Chrome, which makes
 ## Usage
 
 - Click the Chrome Extension icon, and then there is a popup page.
-- Add the URL in the popup page where you want to guard the OpenSumi IDE shortcuts.
+- Add the URL which can be a match pattern in the popup page where the extension will guard the OpenSumi IDE shortcuts.
 - Click the keyboard icon in the upper right corner of the popup page to go to [the shortcut settings page](chrome://extensions/shortcuts), and then input the conflicting shortcuts.
+
+## Match patterns
+
+### Basic Syntax
+
+```text
+<url-pattern> := <scheme>://<host><path>
+<scheme> := '*' | 'http' | 'https'
+<host> := '*' | '*.' <any char except '/' and '*'>+
+<path> := '/' <any chars>
+```
+
+### Examples
+
+| Pattern                            | What it does                                                 | Examples of matching URLs                                    |
+| ---------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `https://*/*`                      | Matches any URL that uses the `https` scheme                 | https://www.google.com/<br/>https://example.org/foo/bar.html |
+| `https://*/foo*`                   | Matches any URL that uses the `https` scheme, on any host, as long as the path starts with `/foo` | https://example.com/foo/bar.html<br/>https://www.google.com/foo |
+| `https://*.google.com/foo*bar`     | Matches any URL that uses the `https` scheme, is on a google.com host (such as www.google.com, docs.google.com, or google.com), as long as the path starts with `/foo` and ends with `bar` | https://www.google.com/foo/baz/bar<br/>https://docs.google.com/foobar |
+| `https://example.org/foo/bar.html` | Matches the specified URL                                    | https://example.org/foo/bar.html                             |
+| `http://127.0.0.1/*`               | Matches any URL that uses the `http` scheme and is on the host 127.0.0.1 | http://127.0.0.1/<br/>http://127.0.0.1/foo/bar.html          |
+| `*://mail.google.com/*`            | Matches any URL that starts with `http://mail.google.com` or `https://mail.google.com` | http://mail.google.com/foo/baz/bar<br/>https://mail.google.com/foobar |
+
+> Reference [Match patterns - Chrome Developers](https://developer.chrome.com/docs/extensions/mv3/match_patterns/)
 
 ## Guarded shortcuts
 

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -23,6 +23,10 @@
     "message": "Delete",
     "description": ""
   },
+  "getCurrentUrl": {
+    "message": "Write the current URL",
+    "description": ""
+  },
   "goShortcut": {
     "message": "Go to the shortcut settings page",
     "description": ""
@@ -43,8 +47,8 @@
     "message": "Successfully updated",
     "description": ""
   },
-  "supportRegular": {
-    "message": "Support regular expressions to add a URL",
+  "supportMatchPatterns": {
+    "message": "Support using a match pattern to add a URL",
     "description": ""
   },
   "updateFailEmpty": {

--- a/src/_locales/zh/messages.json
+++ b/src/_locales/zh/messages.json
@@ -4,11 +4,11 @@
     "description": ""
   },
   "addFailEmpty": {
-    "message": "在添加前请先输入URL",
+    "message": "在添加前请先输入 URL",
     "description": ""
   },
   "addFailExist": {
-    "message": "URL已经存在",
+    "message": "URL 已经存在",
     "description": ""
   },
   "appDesc": {
@@ -21,6 +21,10 @@
   },
   "delete": {
     "message": "删除",
+    "description": ""
+  },
+  "getCurrentUrl": {
+    "message": "写入当前 URL",
     "description": ""
   },
   "goShortcut": {
@@ -43,16 +47,16 @@
     "message": "更新成功",
     "description": ""
   },
-  "supportRegular": {
-    "message": "支持正则表达式添加URL",
+  "supportMatchPatterns": {
+    "message": "支持使用匹配模式添加 URL",
     "description": ""
   },
   "updateFailEmpty": {
-    "message": "URL不能为空",
+    "message": "URL 不能为空",
     "description": ""
   },
   "updateFailExist": {
-    "message": "URL已经存在",
+    "message": "URL 已经存在",
     "description": ""
   }
 }

--- a/src/pages/popup/index.tsx
+++ b/src/pages/popup/index.tsx
@@ -5,9 +5,9 @@ import { Button } from '@opensumi/ide-components/lib/button';
 import { Input } from '@opensumi/ide-components/lib/input';
 import { message } from '@opensumi/ide-components/lib/message';
 import { RecycleList } from '@opensumi/ide-components/lib/recycle-list';
+import { Tooltip } from '@opensumi/ide-components/lib/tooltip';
 
 import styles from './popup.module.less';
-import { Tooltip } from '@opensumi/ide-components/lib/tooltip';
 
 const Popup = () => {
   const [urls, setUrls] = React.useState<string[]>([]);
@@ -37,8 +37,8 @@ const Popup = () => {
   };
 
   const handleAddUrl = () => {
-    if (addingUrl) {
-      const trimedAddingNewUrl = addingUrl.trim();
+    const trimedAddingNewUrl = addingUrl.trim();
+    if (trimedAddingNewUrl) {
       if (urls.some((url) => url === trimedAddingNewUrl)) {
         message.error(chrome.i18n.getMessage('addFailExist'), 3);
       } else {
@@ -101,8 +101,8 @@ const Popup = () => {
     };
 
     const handleEditUrl = (index: number) => {
-      if (editingUrl) {
-        const trimedEditingNewUrl = editingUrl.trim();
+      const trimedEditingNewUrl = editingUrl.trim();
+      if (trimedEditingNewUrl) {
         if (
           urls.some((url, idx) => url === trimedEditingNewUrl && idx !== index)
         ) {
@@ -199,7 +199,7 @@ const Popup = () => {
       <div className={styles['add-url-section']}>
         <Input
           className={styles.input}
-          placeholder={chrome.i18n.getMessage('supportRegular')}
+          placeholder={chrome.i18n.getMessage('supportMatchPatterns')}
           value={addingUrl}
           onValueChange={handleChangeAddInput}
           onPressEnter={handlePressAddUrlEnter}

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -1,4 +1,5 @@
 import * as BrowserCommands from './browser-commands';
+import { matchUrl } from './match-url';
 
 let urls: string[] = [];
 let os: string;
@@ -61,18 +62,9 @@ function reissueKeyDownEvent({
   });
 }
 
-function isRegExp(url: string | RegExp): url is RegExp {
-  try {
-    RegExp(url);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function isUrlHit(targetUrl: string) {
   for (const url of urls) {
-    if (targetUrl === url || (isRegExp(url) && RegExp(url).test(targetUrl))) {
+    if (matchUrl(targetUrl, url)) {
       return true;
     }
   }

--- a/src/scripts/match-url.ts
+++ b/src/scripts/match-url.ts
@@ -1,0 +1,48 @@
+function removeFirstSegment(segments: string): string {
+  const dotIndex = segments.indexOf('.');
+  return dotIndex === -1 ? '' : segments.slice(dotIndex + 1);
+}
+
+/* 
+  https://developer.chrome.com/docs/extensions/mv3/match_patterns/
+  Here's the basic syntax:
+  <url-pattern> := <scheme>://<host><path>
+  <scheme> := '*' | 'http' | 'https' | 'file' | 'ftp' | 'urn'
+  <host> := '*' | '*.' <any char except '/' and '*'>+
+  <path> := '/' <any chars> 
+*/
+function matchPattern(url: string, pattern: string): boolean {
+  url = url.trim();
+  const patternResults = /^(\*|https?):\/\/(\*|(?:\*\.)?[^/*]+)(\/.*)$/.exec(pattern);
+  const urlResults = /^(\*|https?):\/\/(\*|(?:\*\.)?[^/*]+)(\/.*)$/.exec(url);
+  if (!(patternResults && urlResults)) {
+    return false;
+  }
+  const [, scheme, host, path] = urlResults;
+  const [, patternScheme, patternHost, patternPath] = patternResults;
+  if (patternScheme !== '*' && scheme !== patternScheme) {
+    return false;
+  }
+  if (!patternHost.startsWith('*.') && patternHost !== '*' && host !== patternHost) {
+    return false;
+  }
+  // https://*.google.com matches www.google.com and google.com
+  if (patternHost.startsWith('*.') && removeFirstSegment(host) !== patternHost.slice(2) && host !== patternHost.slice(2)) {
+    return false;
+  }
+  const regExp = new RegExp(
+    `^${patternPath.replace(/[*]/g, '[^]*')}$`,
+  );
+  if (!regExp.test(path)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @param url 当前标签页的 URL
+ * @param pattern 用于匹配的匹配模式
+ */
+export function matchUrl(url: string, pattern: string): boolean {
+  return matchPattern(url, pattern);
+}


### PR DESCRIPTION
### Background or solution
closes #5 

### Changelog
-  使用匹配模式匹配 URL 代替 JS 正则表达式匹配
-  补充了匹配模式的文档
-  完善本地化的描述
-  URL判空应在 trimed 后进行判断

