### PR TITLE
fix: initialize URLs in time

### DIFF
--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -2,18 +2,20 @@ import * as BrowserCommands from './browser-commands';
 import { matchUrl } from './match-url';
 
 let urls: string[] = [];
+let shouldInitialize = true;
 let os: string;
 
 chrome.runtime.getPlatformInfo((platformInfo) => {
   os = platformInfo.os;
 });
 
-(async () => {
+async function initializeUrls() {
   const item = await chrome.storage.sync.get('urls');
   if (item.urls) {
     urls = item.urls;
   }
-})();
+  shouldInitialize = false;
+}
 
 chrome.storage.onChanged.addListener(async (changes) => {
   // 监听到 urls 的变化
@@ -77,6 +79,8 @@ chrome.commands.onCommand.addListener(async (command, tab) => {
   if (!tabId || !tabUrl) {
     return;
   }
+
+  shouldInitialize && (await initializeUrls());
 
   // 补发 ide 的快捷键不用区分大小写
   switch (command) {


### PR DESCRIPTION
fixes #18

### 问题还原场景：

- 事先复制好 IDE 运行的网址，打开浏览器并使用鼠标右键选择粘贴并跳转选项。

- 输入守护的快捷键，可以发现第一次输入的快捷键失效。

### 原因：
后台脚本还未从 `storage`  中初始化 `urls` ，`urls`  是一个空数组，因而 [`isUrlHit`](https://github.com/opensumi/shortcuts-guard/blob/main/src/scripts/background.ts#L65) 函数返回 false，所以快捷键失效。

### 解决方法：
在处理事件的函数里做一个 `urls` 是否初始化的判断，确保 `urls` 得到初始化。